### PR TITLE
Fix computation bug in matrix3x3 inverse

### DIFF
--- a/Sources/kvSIMD/KvMatrices.swift
+++ b/Sources/kvSIMD/KvMatrices.swift
@@ -1197,16 +1197,16 @@ public struct simd_float3x3 : Equatable, CustomDebugStringConvertible {
     @inlinable
     public var inverse: simd_float3x3 {
         let col0 = simd_float3(columns.1.y * columns.2.z - columns.1.z * columns.2.y,
-                               columns.1.z * columns.2.x - columns.0.y * columns.2.z,
-                               columns.0.y * columns.2.y - columns.1.y * columns.2.x)
+                               columns.2.y * columns.0.z - columns.0.y * columns.2.z,
+                               columns.0.y * columns.1.z - columns.0.z * columns.1.y)
 
-        let col1 = simd_float3(columns.2.x * columns.2.y - columns.1.x * columns.2.z,
-                               columns.0.x * columns.2.z - columns.2.x * columns.2.x,
-                               columns.1.x * columns.2.x - columns.0.x * columns.2.y)
+        let col1 = simd_float3(columns.2.x * columns.1.z - columns.1.x * columns.2.z,
+                               columns.0.x * columns.2.z - columns.2.x * columns.0.z,
+                               columns.0.z * columns.1.x - columns.0.x * columns.1.z)
 
-        let col2 = simd_float3(columns.1.x * columns.1.z - columns.2.x * columns.1.y,
-                               columns.2.x * columns.0.y - columns.0.x * columns.1.z,
-                               columns.0.x * columns.1.y - columns.1.x * columns.0.y)
+        let col2 = simd_float3(columns.1.x * columns.2.y - columns.2.x * columns.1.y,
+                               columns.0.y * columns.2.x - columns.0.x * columns.2.y,
+                               columns.0.x * columns.1.y - columns.0.y * columns.1.x)
 
         let determinant⁻¹ = 1.0 / (columns.0.x * col0.x + columns.1.x * col0.y + columns.2.x * col0.z)
 
@@ -3625,16 +3625,16 @@ public struct simd_double3x3 : Equatable, CustomDebugStringConvertible {
     @inlinable
     public var inverse: simd_double3x3 {
         let col0 = simd_double3(columns.1.y * columns.2.z - columns.1.z * columns.2.y,
-                                columns.1.z * columns.2.x - columns.0.y * columns.2.z,
-                                columns.0.y * columns.2.y - columns.1.y * columns.2.x)
+                                columns.2.y * columns.0.z - columns.0.y * columns.2.z,
+                                columns.0.y * columns.1.z - columns.0.z * columns.1.y)
 
-        let col1 = simd_double3(columns.2.x * columns.2.y - columns.1.x * columns.2.z,
-                                columns.0.x * columns.2.z - columns.2.x * columns.2.x,
-                                columns.1.x * columns.2.x - columns.0.x * columns.2.y)
+        let col1 = simd_double3(columns.2.x * columns.1.z - columns.1.x * columns.2.z,
+                                columns.0.x * columns.2.z - columns.2.x * columns.0.z,
+                                columns.0.z * columns.1.x - columns.0.x * columns.1.z)
 
-        let col2 = simd_double3(columns.1.x * columns.1.z - columns.2.x * columns.1.y,
-                                columns.2.x * columns.0.y - columns.0.x * columns.1.z,
-                                columns.0.x * columns.1.y - columns.1.x * columns.0.y)
+        let col2 = simd_double3(columns.1.x * columns.2.y - columns.2.x * columns.1.y,
+                                columns.0.y * columns.2.x - columns.0.x * columns.2.y,
+                                columns.0.x * columns.1.y - columns.0.y * columns.1.x)
 
         let determinant⁻¹ = 1.0 / (columns.0.x * col0.x + columns.1.x * col0.y + columns.2.x * col0.z)
 

--- a/Tests/kvSIMDTests/KvMatrixTests.swift
+++ b/Tests/kvSIMDTests/KvMatrixTests.swift
@@ -568,6 +568,11 @@ final class KvMatrixTests : XCTestCase {
         assertEqual(D2x2(columns: Cols2x2d).inverse, simd.double2x2(columns: Cols2x2d).inverse, IsEqual(_:_:))
         assertEqual(D3x3(columns: Cols3x3d).inverse, simd.double3x3(columns: Cols3x3d).inverse, IsEqual(_:_:))
         assertEqual(D4x4(columns: Cols4x4d).inverse, simd.double4x4(columns: Cols4x4d).inverse, IsEqual(_:_:))
+
+        let Cols3x3d1 = (SIMD3<Double>(4, 0, -15), SIMD3<Double>(0, 4, -12), SIMD3<Double>(0, 0, 1))
+        assertEqual(D3x3(columns: Cols3x3d1).inverse, simd.double3x3(columns: Cols3x3d1).inverse, IsEqual(_:_:))
+        let Cols3x3f1 = (SIMD3<Float>(4, 0, -15), SIMD3<Float>(0, 4, -12), SIMD3<Float>(0, 0, 1))
+        assertEqual(F3x3(columns: Cols3x3f1).inverse, simd.float3x3(columns: Cols3x3f1).inverse, IsEqual(_:_:))
     }
 
 


### PR DESCRIPTION
There is a bug in the `inverse` computation of 3x3 matrixes. This PR fixes it.
Thanks for making kvSIMD!